### PR TITLE
Removing the "s" that is causing library import to fail

### DIFF
--- a/dtaidistance/dtw.py
+++ b/dtaidistance/dtw.py
@@ -20,7 +20,7 @@ from .util import SeriesContainer, dtaidistance_dir
 logger = logging.getLogger("be.kuleuven.dtai.distance")
 
 try:
-s    from . import dtw_c
+    from . import dtw_c
 except ImportError:
     # logger.info('C library not available')
     dtw_c = None


### PR DESCRIPTION
Issue on line 23 causing problems when trying to import dtw