### PR TITLE
add build files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ dtw_cc*.so
 ed_cc*.c
 ed_cc*.py
 ed_cc*.so
+util_numpy_cc.c
 .cache
 .benchmarks
 .eggs
@@ -19,6 +20,8 @@ dtaidistance/*html
 dtaidistance/*so
 dtaidistance/__pycache__/
 dtaidistance/dtw_c.*.pyd
+dtaidistance/dtw_cc*.pyd
+dtaidistance/ed_cc*.pyd
 README
 README.rst
 benchmark*.svg


### PR DESCRIPTION
These files get generated on my system when running `python setup.py build_ext --inplace` and are probably not meant to be included. Full list that the regex' should match:
```text
dtaidistance/dtw_cc.cp38-win_amd64.pyd
dtaidistance/dtw_cc_numpy.cp38-win_amd64.pyd
dtaidistance/dtw_cc_omp.cp38-win_amd64.pyd
dtaidistance/ed_cc.cp38-win_amd64.pyd
dtaidistance/util_numpy_cc.c
```