### PR TITLE
FIX: Unsupported argument in Python kmeans

### DIFF
--- a/dtaidistance/clustering/__init__.py
+++ b/dtaidistance/clustering/__init__.py
@@ -1,3 +1,4 @@
 
 from .hierarchical import Hierarchical, BaseTree, HierarchicalTree, LinkageTree, Hooks
 from .medoids import KMedoids
+from .kmeans import KMeans

--- a/dtaidistance/clustering/kmeans.py
+++ b/dtaidistance/clustering/kmeans.py
@@ -97,7 +97,6 @@ class KMeans(Medoids):
         """
         if dists_options is None:
             dists_options = {}
-        dists_options['compact'] = False
         self.means = [None] * k
         self.max_it = max_it
         self.max_dba_it = max_dba_it
@@ -150,7 +149,7 @@ class KMeans(Medoids):
                 fn_dm = distance_matrix_fast
             else:
                 fn_dm = distance_matrix
-            model = KMedoids(fn_dm, self.dists_options, k=self.k)
+            model = KMedoids(fn_dm, {**self.dists_options, **{'compact': False}}, k=self.k)
             cluster_idx = model.fit(sample)
             self.means = [self.series[idx] for idx in cluster_idx.keys()]
             logger.debug('... Done')


### PR DESCRIPTION
The `distance` function does not allow the 'compact' argument, which caused
a TypeError when running the Python version of K-means.

Also adds KMeans to the `__init__` file.