### PR TITLE
adds missing `dtw_ndim` import to documentation

### DIFF
--- a/docs/usage/dtw.rst
+++ b/docs/usage/dtw.rst
@@ -260,6 +260,7 @@ dimension to be the series index (thus timestep).
 Example:
 
 ::
+    from dtaidistance import dtw_ndim
 
     s1 = np.array([[0, 0],
                    [0, 1],
@@ -271,7 +272,7 @@ Example:
                    [0, 1],
                    [0, .5],
                    [0, 0]], dtype=np.double)
-    d = distance(s1, s2)
+    d = dtw_ndim.distance(s1, s2)
 
 This method returns the dependent DTW (DTW_D) distance between two
 n-dimensional sequences. If you want to compute the independent DTW


### PR DESCRIPTION
It may be not obvious for many people that to compare two multi-dimensional sequences you need to actually use `dtw_ndim` instead of `dtw`