### PR TITLE
fix msvc setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -184,8 +184,8 @@ class MyBuildExtCommand(BuildExtCommand):
             print('Using LLVM settings ({})'.format(self.compiler.compiler[0]))
             c = 'llvm'
         elif self.distribution.forcegnugcc or \
-                (c == "unix" and ("gnu-gcc" in self.compiler.compiler[0]) or
-                                 ("gnu-cc" in self.compiler.compiler[0])):
+                (c == "unix" and (("gnu-gcc" in self.compiler.compiler[0]) or
+                                 ("gnu-cc" in self.compiler.compiler[0]))):
             print('Using GNU GCC settings ({})'.format(self.compiler.compiler[0]))
             c = 'gnugcc'
 


### PR DESCRIPTION
with a460b7cae842ece3a0d0730ed41826efee2610e6 an additional check for
"gnu-cc" was introduced to the code, breaking the setup under windows
for msvc. The additional parentheses fix the logical expression.